### PR TITLE
tweaks to collection display

### DIFF
--- a/usep_app/models.py
+++ b/usep_app/models.py
@@ -289,7 +289,8 @@ class DisplayInscriptionHelper( object ):
           }
         return context
 
-    def update_host( self, hostname, url ):
+    @staticmethod
+    def update_host(hostname, url):
         """ Updates url if needed.
             Allows saxonce and ajax references to work with both `library.brown.edu` and `usepigraphy.brown.edu` urls. """
         if hostname.lower() == u'usepigraphy.brown.edu':

--- a/usep_app/models.py
+++ b/usep_app/models.py
@@ -746,9 +746,9 @@ class Vocab(object):
         u"status": u"Transcription Status",
         u"char": u"Special Characters",
         u"name": u"Names",
-        u"metadata": u"Metadata",
+        u"metadata": u"No Transcription",
         u"transcription": u"Fully Transcribed",
-        u"bib_only": u"Citations",
+        u"bib_only": u"Citation Only",
     }
 
     language_pairs = {

--- a/usep_app/static/usep/css/style.css
+++ b/usep_app/static/usep/css/style.css
@@ -420,6 +420,14 @@ img {
    
 }
 
+.caption.no-image p{
+    width: 100%;
+    float:left;
+    margin-top:0px;
+    -webkit-margin-before: 0px;
+   
+}
+
 .status{
     font-family: 'Vollkorn', serif;
     color:#99827e;
@@ -586,10 +594,6 @@ ul.collection img {
 float: left;
 margin-right: 10px;
 height: 80px;
-}
-
-ul.collection p {
-margin-left: 50px;
 }
 
 ul.collection span.desc {

--- a/usep_app/usep_templates/collectioN.html
+++ b/usep_app/usep_templates/collectioN.html
@@ -36,7 +36,7 @@
           // $("#description > p").slideToggle(500);
             $("button").text(function(i, text){
                 return text === "Expand" ? "Close" : "Expand";
-            })
+            });
         });
     });
 </script>
@@ -57,27 +57,7 @@
       <h2 id="{{ keylang }}">{{ language_group.display }}</h2>
       <div class="collection">
         {% for result in language_group.docs %}
-        <div class="item right-caption">
-             <h3>  <a href="{{ result.url }}">{{ result.id }} </a></h3>
-            <hr>
-          {% if result.image_url %}
-            <img class="thumb" src="{{ result.image_url }}" alt="inscription_thumbnail" width="80" height="80"></img>
-            {% else %}
-            <img class="thumb" src="{{ STATIC_URL }}usep/images/NoImageAvailable.jpg" alt="inscription_thumbnail" width="80" height="80"></img>
-            {% endif %}
-        <div class="caption">
-               <p>
-            <span class="status">({{ result.status }})</span>
-            {% if result.text_genre_desc %}
-         
-                <br/><span class="desc">{{result.text_genre_desc.0}}</span> 
-            {% endif %}
-            {% if show_dates %}
-            <br/><span class="date">(Between {{result.notBefore|era}} and {{result.notAfter|era}})</span>
-                </p>
-            {% endif %}
-        </div>
-        </div>
+        {% include "usep_templates/inscription_result.html" %}
         {% endfor %}
        </div>
       {% endfor %}

--- a/usep_app/usep_templates/collectioN.html
+++ b/usep_app/usep_templates/collectioN.html
@@ -9,7 +9,35 @@
 {% block page_title %}Inscriptions from &nbsp; <span class="id_string">{{ collection_title }}</span>{% endblock page_title %}
 
 {% block content %}
+<script type="text/javascript" language="javascript" src="{{ saxonce_file_url }}"></script>
 <script>
+    var transformer;
+    var xipr;
+    var xml_url_pattern = "{{ xml_url_pattern }}";
+    var onSaxonLoad = function() {
+        transformer = Saxon.newXSLT20Processor(Saxon.requestXML("{{ xsl_url }}"));
+        transformer.setInitialTemplate('bibl');
+        xipr = Saxon.newXSLT20Processor(Saxon.requestXML("{{ xipr_url }}"));
+
+        $(".item .bibl").each(getCitationHTML);
+    };
+
+    function getCitationHTML(idx, node) {
+      var inscription_id = $(node).attr("id");
+      var xml_url = xml_url_pattern
+                        .replace("HOSTNAME", window.location.host)
+                        .replace("SCHEME:", window.location.protocol)
+                        .replace("INSCRIPTION_ID", inscription_id);
+
+        xml = xipr.transformToDocument(Saxon.requestXML(xml_url));
+        frag = transformer.transformToFragment(xml, document);
+        console.log(frag);
+        for (var i = 0; i < frag.children.length; i++) {
+          node.innerHTML += frag.children[i].textContent + "<br/>";
+        }
+    }
+
+
     $(document).ready(function(){
 //        $("#description > p").css('height', 'auto');
     var fullHeight =  $("#description > p").height();

--- a/usep_app/usep_templates/inscription_result.html
+++ b/usep_app/usep_templates/inscription_result.html
@@ -1,21 +1,23 @@
 {% load vocab %}
 
 <div class="item right-caption">
-     <h3>  <a href="{{ result.url }}">{{ result.id }} </a></h3>
-    <hr />
+  <h3><a href="{{ result.url }}">{{ result.id }}</a></h3>
+  <hr />
   {% if result.image_url %}
-    <img class="thumb" src="{{ result.image_url }}" alt="inscription_thumbnail" width="80" height="80"></img>
-    {% endif %}
+  <img class="thumb" src="{{ result.image_url }}" alt="inscription_thumbnail" width="80" height="80"></img>
+  {% endif %}
   <div class="caption {% if not result.image_url %}no-image{% endif %}">
-         <p>
-      {% if result.text_genre_desc %}
-   
-          <br/><span class="desc">{{result.text_genre_desc.0}}</span> 
-      {% endif %}
+     <p>
+      <span class="desc {% if result.status == 'bib_only' %}bibl{% endif %}" id="{{result.id}}">
+        {% if result.text_genre_desc %}
+          {{result.text_genre_desc.0}}
+        {% endif %}
+      </span>
       {% if not result.status == 'transcription' %}<span class="status">({{ result.status|tax }})</span>{% endif %}
-      {% if show_dates %}
+      {% if show_dates and result.notBefore and result.notAfter %}
       <br/><span class="date">(Between {{result.notBefore|era}} and {{result.notAfter|era}})</span>
-          </p>
       {% endif %}
+
+      </p>
   </div>
 </div>

--- a/usep_app/usep_templates/inscription_result.html
+++ b/usep_app/usep_templates/inscription_result.html
@@ -1,0 +1,21 @@
+{% load vocab %}
+
+<div class="item right-caption">
+     <h3>  <a href="{{ result.url }}">{{ result.id }} </a></h3>
+    <hr />
+  {% if result.image_url %}
+    <img class="thumb" src="{{ result.image_url }}" alt="inscription_thumbnail" width="80" height="80"></img>
+    {% endif %}
+  <div class="caption {% if not result.image_url %}no-image{% endif %}">
+         <p>
+      {% if result.text_genre_desc %}
+   
+          <br/><span class="desc">{{result.text_genre_desc.0}}</span> 
+      {% endif %}
+      {% if not result.status == 'transcription' %}<span class="status">({{ result.status|tax }})</span>{% endif %}
+      {% if show_dates %}
+      <br/><span class="date">(Between {{result.notBefore|era}} and {{result.notAfter|era}})</span>
+          </p>
+      {% endif %}
+  </div>
+</div>

--- a/usep_app/usep_templates/publicatioN.html
+++ b/usep_app/usep_templates/publicatioN.html
@@ -28,27 +28,7 @@
       <p>( count: {{ inscription_count }} )</p>
       <div class="collection">
         {% for member in inscriptions %}
-        <div class="item right-caption">
-             <h3><a href="{{ member.url }}">{{ member.id }} </a></h3>
-            {% if member.image_url %}
-            <img class="thumb" src="{{ member.image_url }}" alt="inscription_thumbnail" width="80" height="80"></img>
-            {% else %}
-            <img class="thumb" src="{{ STATIC_URL }}usep/images/NoImageAvailable.jpg" alt="inscription_thumbnail" width="80" height="80"></img>
-            {% endif %}
-            <hr>
-        <div class="caption">
-              <p>
-            <span class="status">({{ member.status }})</span>
-          
-            {% if member.text_genre_desc %}
-            <br/><span class="desc">{{member.text_genre_desc.0}}</span>
-            {% endif %}
-            {% if show_dates %}
-            <br/><span class="date">(Between {{member.notBefore|era}} and {{member.notAfter|era}})</span>
-                </p>
-            {% endif %}
-        </div>
-       </div>
+        {% include "usep_templates/inscription_result.html" with result=member %}
         {% endfor %}
       </ul>
     </div>

--- a/usep_app/usep_templates/results.html
+++ b/usep_app/usep_templates/results.html
@@ -94,7 +94,7 @@ $(document).ready(function () {
     $("li").click(function () {
         $("ul.facet_list", this).toggle();
 		if ($("#symbol", this).text() == "►")
-			$("#symbol", this).text("▼")
+			$("#symbol", this).text("▼");
 		else
 			$("#symbol", this).text("►");
     });
@@ -123,21 +123,7 @@ $(document).ready(function () {
 		{% for result in coll.list %}
 
 		{% block result%}
-		<li>
-			{% if result.image_url %}
-			<img class="thumb" src="{{ result.image_url }}" alt="inscription_thumbnail" width="40" height="40"></img>
-			{% else %}
-			<img class="thumb" src="{{ STATIC_URL }}usep/images/NoImageAvailable.jpg" alt="inscription_thumbnail" width="40" height="40"></img>
-			{% endif %}
-			<a href="{{ result.url }}">{{ result.id }} </a>
-			{% if show_dates %}
-			<span class="date">(Between {{result.notBefore|era}} and {{result.notAfter|era}})</span>
-			{% endif %}
-			<span class="status">({{ result.status }})</span>
-			{% if result.text_genre_desc %}
-			<br/><span class="desc">{{result.text_genre_desc.0}}</span>
-			{% endif %}
-		</li>
+        {% include "usep_templates/inscription_result.html" %}
 		{% endblock result %}
 
 
@@ -175,7 +161,4 @@ $(document).ready(function () {
 {% endblock facets%}
 </div>
 
-
-
 {% endblock content %}
-

--- a/usep_app/views.py
+++ b/usep_app/views.py
@@ -72,7 +72,7 @@ def collection( request, collection ):
             u'inscription_count': num,
             u'display': display_dict,
             u'flat_collection': FlatCollection.objects.get(collection_code=collection),
-            u'show_dates':False,
+            u'show_dates':True,
             }
         return data_dict
     def build_response( format, callback ):
@@ -156,7 +156,9 @@ def pub_children( request, publication ):
     data_dict = {
         u'publication_title': title,
         u'inscriptions': pub.inscription_entries,
-        u'inscription_count': pub.inscription_count, }
+        u'inscription_count': pub.inscription_count,
+        u'show_dates':True,
+    }
     ## respond
     format = request.GET.get( u'format', None )
     callback = request.GET.get( u'callback', None )

--- a/usep_app/views.py
+++ b/usep_app/views.py
@@ -73,6 +73,10 @@ def collection( request, collection ):
             u'display': display_dict,
             u'flat_collection': FlatCollection.objects.get(collection_code=collection),
             u'show_dates':True,
+            u'xml_url_pattern':settings_app.DISPLAY_INSCRIPTION_XML_URL_PATTERN,
+            u'xsl_url': DisplayInscriptionHelper.update_host(request.get_host(), settings_app.DISPLAY_INSCRIPTION_XSL_URL),
+            u'saxonce_file_url': DisplayInscriptionHelper.update_host(request.get_host(), settings_app.DISPLAY_INSCRIPTION_SAXONCE_FILE_URL),
+            u'xipr_url': DisplayInscriptionHelper.update_host(request.get_host(), settings_app.DISPLAY_INSCRIPTION_XIPR_URL)
             }
         return data_dict
     def build_response( format, callback ):


### PR DESCRIPTION
fixes #26 

Changes to the way inscriptions are displayed on a single collection page:

- If they have no image, show no image.
- Rename "metadata" to "No Transcription" and "bib_only" to "Citation Only". 
- Show bib for bib_only directly in the collection page.
- Display dates wherever available.

plus:

- Changed a few JS lines to make JSHint happy
